### PR TITLE
belindas-closet-android_1_68_fix-email-address-length

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/screen/Login.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Login.kt
@@ -225,7 +225,7 @@ fun LoginPage(navController: NavHostController) {
 // Validation functions
 fun validateEmail(email: String): Boolean {
     return Patterns.EMAIL_ADDRESS.matcher(email)
-        .matches() && email.isNotEmpty() && email.isNotBlank() && email.length > 5 && email.length < 30 && email.contains(
+        .matches() && email.isNotEmpty() && email.isNotBlank() && email.length > 5 && email.length < 254 && email.contains(
         "@"
     )
 }


### PR DESCRIPTION
Resolves #68 

This PR fixes the bug of an "Invalid email!" error occurring when the user enters an email address longer than 30 characters. I adjusted the maximum email address length from 30 characters to 254 characters.

<img width="220" alt="Screenshot 2023-10-16 050118" src="https://github.com/SeattleColleges/belindas-closet-android/assets/77607212/4982c6d6-a5ac-47ba-b298-979cf060a541">
<img width="215" alt="Screenshot 2023-10-16 050147" src="https://github.com/SeattleColleges/belindas-closet-android/assets/77607212/6ed0d673-7cb7-457c-9f90-d67c561e24af">
