### PR TITLE
Belinda_Androis_Sprint_2_Fix_Duplicate_Text

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/screen/Update.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Update.kt
@@ -264,6 +264,7 @@ fun UpdateProductCard(product: Product, navController: NavController) {
                         }
                     }
                 } else {
+                    Text("None Edit Mode")
                     Row(
                         modifier = Modifier
                             .size(200.dp)

--- a/app/src/main/java/com/example/belindas_closet/screen/Update.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Update.kt
@@ -199,27 +199,6 @@ fun UpdateProductCard(product: Product, navController: NavController) {
                 Text(text = "Size: ${product.productSizes}")
                 Text(text = "Description: ${product.productDescription}")
 
-                // Add a delete icon and button
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(8.dp),
-                    verticalArrangement = Arrangement.Center
-                ) {
-
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    Button(
-                        onClick = { isDelete = !isDelete },
-                        modifier = Modifier.padding(8.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete"
-                        )
-                    }
-                }
-
                 // Display the text fields and buttons
                 if (isEditing) {
                     TextFieldEditable(
@@ -264,23 +243,8 @@ fun UpdateProductCard(product: Product, navController: NavController) {
                         }
                     }
                 } else {
-                    Text("None Edit Mode")
-                    Row(
-                        modifier = Modifier
-                            .size(200.dp)
-                            .padding(16.dp),
-                    ) {
-                        Text(
-                            text = "Name: ${product.productType}", style = TextStyle(
-                                fontSize = 15.sp,
-                                fontWeight = FontWeight.Bold,
-                                fontFamily = FontFamily.Default,
-                            ), modifier = Modifier.wrapContentSize()
-                        )
-                        Text(text = "Size: ${product.productSizes}")
-                        Text(text = "Description: ${product.productDescription}")
 
-                        // Display the text fields and buttons
+                    // Display the text fields and buttons
                         if (isEditing) {
                             TextFieldEditable(
                                 initialName = product.productType.name,
@@ -373,7 +337,6 @@ fun UpdateProductCard(product: Product, navController: NavController) {
             }
         }
     }
-}
 
 @Composable
 fun UpdateProductList(products: List<Product>, navController: NavController) {


### PR DESCRIPTION
Fixe the duplicate description bug in the update product page.
The is the origin page with bug
<img width="195" alt="Screenshot 2023-11-07 at 8 31 30 PM" src="https://github.com/SeattleColleges/belindas-closet-android/assets/117953848/12e6e293-38b4-4ea1-871e-5c42dfd8ac01">
Here is now the update page with bug fixed 
<img width="165" alt="Screenshot 2023-11-09 at 10 23 06 PM" src="https://github.com/SeattleColleges/belindas-closet-android/assets/117953848/e70e728b-8bdc-4d54-9d74-0abcf5bc3dbb">

