### PR TITLE
belindas-closet-android_03_170_consistent-widths

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
@@ -119,10 +119,11 @@ fun ProductDetailPage(navController: NavController) {
 
 @Composable
 fun ProductDetailCard(product: Product, navController: NavController) {
+    val density = Resources.getSystem().displayMetrics.density
     Card(
         modifier = Modifier
             .padding(8.dp)
-            .widthIn(0.dp, (Resources.getSystem().displayMetrics.widthPixels*0.3).dp)
+            .widthIn(0.dp, (Resources.getSystem().displayMetrics.widthPixels * .8/density).dp)
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
resolves #170 . In #170 , you can see the card widths can be inconsistent across devices with different pixel densities. By factoring the device's density into the card width limit, the cards are now more consistent. Here's a couple screenshots from devices with different pixel densities:

![34](https://github.com/SeattleColleges/belindas-closet-android/assets/91910852/0741cd14-4ac9-4309-99f0-50f711a7d210)
![xl](https://github.com/SeattleColleges/belindas-closet-android/assets/91910852/8cd975c9-7baf-409b-8b5e-87af821982a5)
