### PR TITLE
belindas-closet-android_3_165_add-archive-functionality-to-button

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/data/Datasource.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/Datasource.kt
@@ -3,10 +3,10 @@ package com.example.belindas_closet.data
 import com.example.belindas_closet.R
 import com.example.belindas_closet.model.Product
 import com.example.belindas_closet.model.ProductGender
-import com.example.belindas_closet.model.ProductSizes
 import com.example.belindas_closet.model.ProductSizePantsInseam
 import com.example.belindas_closet.model.ProductSizePantsWaist
 import com.example.belindas_closet.model.ProductSizeShoes
+import com.example.belindas_closet.model.ProductSizes
 import com.example.belindas_closet.model.ProductType
 
 class Datasource {
@@ -23,7 +23,7 @@ class Datasource {
                 ProductSizePantsInseam.XS,
                 "This is a beautiful dress",
                 R.drawable.product1.toString(),
-                "1"
+                "655b46baa82ef869be176174"
             )
         )
         productList.add(
@@ -127,7 +127,7 @@ class Datasource {
                 ProductSizePantsInseam.M,
                 "This is a belt",
                 R.drawable.product8.toString(),
-                "9"
+                "655b7871eabb25411ada6138"
             )
         )
         productList.add(

--- a/app/src/main/java/com/example/belindas_closet/data/Datasource.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/Datasource.kt
@@ -67,6 +67,7 @@ class Datasource {
         )
         productList.add(
             Product(
+                ProductType.JACKET_BLAZER,
                 ProductGender.MALE,
                 ProductSizeShoes.SELECT_SIZE,
                 ProductSizes.M,

--- a/app/src/main/java/com/example/belindas_closet/data/network/HttpRoutes.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/HttpRoutes.kt
@@ -4,6 +4,7 @@ object HttpRoutes {
     private const val BASE_URL = "http://10.0.2.2:3000/api"
     const val PRODUCTS = "$BASE_URL/products"
     const val PRODUCT = "$BASE_URL/products/{id}"
+    const val ARCHIVE = "$BASE_URL/products/archive"
     const val LOGIN = "$BASE_URL/auth/login"
     const val FORGOT_PASSWORD = "$BASE_URL/auth/forgot-password"
     const val SIGNUP = "$BASE_URL/auth/signup"

--- a/app/src/main/java/com/example/belindas_closet/data/network/auth/ArchiveService.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/auth/ArchiveService.kt
@@ -1,0 +1,42 @@
+package com.example.belindas_closet.data.network.auth
+
+import com.example.belindas_closet.MainActivity
+import com.example.belindas_closet.data.network.dto.auth_dto.ArchiveRequest
+import com.example.belindas_closet.data.network.dto.auth_dto.ArchiveResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.DEFAULT
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+interface ArchiveService {
+    suspend fun archive(archiveRequest: ArchiveRequest) : ArchiveResponse?
+
+    companion object {
+        fun create() : ArchiveService {
+            return ArchiveServiceImpl(
+                client = HttpClient(Android) {
+                    install(ContentNegotiation) {
+                        json(Json {
+                            prettyPrint = true
+                            isLenient = true
+                            ignoreUnknownKeys = true
+                        })
+                    }
+                    install (Logging) {
+                        level = LogLevel.ALL
+                        logger = Logger.DEFAULT
+                    }
+                },
+                getToken = suspend {
+                    MainActivity.getPref().getString("token", "") ?: ""
+                }
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/belindas_closet/data/network/auth/ArchiveServiceImpl.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/auth/ArchiveServiceImpl.kt
@@ -1,0 +1,48 @@
+package com.example.belindas_closet.data.network.auth
+
+import com.example.belindas_closet.data.network.HttpRoutes
+import com.example.belindas_closet.data.network.dto.auth_dto.ArchiveRequest
+import com.example.belindas_closet.data.network.dto.auth_dto.ArchiveResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.RedirectResponseException
+import io.ktor.client.plugins.ServerResponseException
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.util.InternalAPI
+import kotlinx.serialization.json.Json
+
+class ArchiveServiceImpl (
+    private val client: HttpClient,
+    private val getToken: suspend () -> String
+) : ArchiveService {
+    @OptIn(InternalAPI::class)
+    override suspend fun archive(archiveRequest: ArchiveRequest): ArchiveResponse? {
+        return try {
+            val token = getToken()
+            val response = client.put {
+                url("${HttpRoutes.ARCHIVE}/${archiveRequest.id}")
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                header(HttpHeaders.Authorization, "Bearer $token")
+                body = Json.encodeToString(ArchiveRequest.serializer(), archiveRequest)
+            }
+            response.body()
+        } catch (e: RedirectResponseException) {
+            println("Error: ${e.response.status.description}")
+            null
+        } catch (e: ClientRequestException) {
+            println("Error: ${e.response.status.description}")
+            null
+        } catch (e: ServerResponseException) {
+            println("Error: ${e.response.status.description}")
+            null
+        } catch (e: Exception) {
+            println("Error: ${e.message}")
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/example/belindas_closet/data/network/auth/LoginService.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/auth/LoginService.kt
@@ -13,6 +13,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
 interface LoginService {
+
     suspend fun login(loginRequest: LoginRequest) : LoginResponse?
 
     companion object {

--- a/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/ArchiveRequest.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/ArchiveRequest.kt
@@ -1,0 +1,13 @@
+package com.example.belindas_closet.data.network.dto.auth_dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ArchiveRequest(
+    @SerialName("id")
+    val id: String,
+
+    @SerialName("role")
+    val role: Role
+)

--- a/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/ArchiveResponse.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/ArchiveResponse.kt
@@ -1,0 +1,10 @@
+package com.example.belindas_closet.data.network.dto.auth_dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ArchiveResponse(
+    @SerialName("isSold")
+    val isSold: Boolean = false
+)

--- a/app/src/main/java/com/example/belindas_closet/screen/Login.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Login.kt
@@ -292,11 +292,12 @@ fun NSCMascot() {
 }
 
 suspend fun loginWithValidCredentials(email: String, password: String, navController: NavHostController, current: Context) {
-    // login with valid credentials
     try {
         val loginRequest = LoginRequest(email, password)
         val loginResponse = LoginService.create().login(loginRequest)
         if (loginResponse != null) {
+            val token = loginResponse.token
+            saveToken(token)
             MainActivity.getPref().edit().putString("token", loginResponse.token).apply()
             navController.navigate(Routes.AddProduct.route)
             Toast.makeText(
@@ -304,6 +305,7 @@ suspend fun loginWithValidCredentials(email: String, password: String, navContro
                 "Welcome ${getName(loginResponse.token)} to Belinda's Closet!",
                 Toast.LENGTH_SHORT
             ).show()
+            loginResponse.token
         } else {
             Toast.makeText(
                 current,
@@ -331,4 +333,8 @@ fun getName(token: String): String? {
         e.printStackTrace()
         null
     }
+}
+
+fun saveToken(token: String) {
+    MainActivity.getPref().edit().putString("token", token).apply()
 }

--- a/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
@@ -1,23 +1,14 @@
 package com.example.belindas_closet.screen
 
 
-import android.app.Activity
 import android.content.res.Resources
-import android.util.DisplayMetrics
-import android.view.Display
-import android.view.Window
-import android.view.WindowManager
-import android.view.WindowMetrics
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -34,29 +25,22 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.capitalize
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import com.example.belindas_closet.MainActivity
-import com.example.belindas_closet.R
-import com.example.belindas_closet.Routes
-import com.example.belindas_closet.model.Product
-import com.example.belindas_closet.data.Datasource
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.material3.rememberDrawerState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.belindas_closet.MainActivity
+import com.example.belindas_closet.R
+import com.example.belindas_closet.Routes
+import com.example.belindas_closet.data.Datasource
+import com.example.belindas_closet.model.Product
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,10 +41,13 @@
 
     <!--    Product Update Screen Strings    -->
     <string name="update_delete_confirm_text">Are you sure you want to delete this product?</string>
-    <string name="update_confirm_confirm_text">Are you sure you want to archive this product?</string>
+    <string name="update_archive_confirm_text">Are you sure you want to archive this product?</string>
     <string name="update_save_confirm_text">Are you sure you want to save this product?</string>
     <string name="update_cancel_confirm_text">Are you sure you want to cancel this edit?</string>
     <string name="update_page_title">Update Product</string>
+    <string name="archive_successful_toast">Archival successful!</string>
+    <string name="archive_invalid_id">Invalid ID!</string>
+    <string name="archive_failed_toast">Archival failed, please try again!</string>
 
     <!--    Forgot Password Screen Strings    -->
     <string name="forgot_password">Forgot Password?</string>


### PR DESCRIPTION
Resolves #165 

This PR does the following:

- Connects the API archive endpoint to the archive button
- Saves bearer authentication token when the user logs in and uses it to authorize that the user is an admin so they are able to archive a product (will throw error if the user's account does not have the admin role)
- For manual testing purposes, updates the handbag in the 'Accessories' category to be a 24-character hex string as the `id` in Datasource.kt because MongoDB generates the ObjectId in this format (will otherwise throw an invalid id error). 

IMPORTANT: You need to add the changes from the [backend PR](https://github.com/SeattleColleges/belindas-closet-nestjs/pull/61) for this feature to work properly.

https://github.com/SeattleColleges/belindas-closet-android/assets/77591083/26b8a43c-cb8d-49ab-a5ba-4f3fe66d3121

<img width="957" alt="archive - log" src="https://github.com/SeattleColleges/belindas-closet-android/assets/77591083/963bd918-fdd3-42dd-a0d9-da20006f8711">

