### PR TITLE
belinda-android-fix-IndividualProductUpdatePage-bug

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/Routes.kt
+++ b/app/src/main/java/com/example/belindas_closet/Routes.kt
@@ -9,6 +9,6 @@ sealed class Routes (val route: String) {
     object AddProduct: Routes("Add Product")
     object ForgotPassword: Routes("Forgot Password")
     object IndividualProduct: Routes("Individual_Product")
-    object IndividualProductUpdate: Routes("Individual_Product_Update")
+    object IndividualProductUpdatePage: Routes("Individual_Product_Update")
     object AdminView: Routes("Admin_View")
 }

--- a/app/src/main/java/com/example/belindas_closet/screen/IndividualProduct.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/IndividualProduct.kt
@@ -60,7 +60,7 @@ fun IndividualProductPage(navController: NavController, productId: String) {
         actions = {
             IconButton(
                 onClick = {
-                    navController.navigate(Routes.IndividualProductUpdate.route + "/${productId}")
+                    navController.navigate(Routes.IndividualProductUpdatePage.route + "/$productId")
                 }
             ) {
                 Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")

--- a/app/src/main/java/com/example/belindas_closet/screen/ScreenMain.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/ScreenMain.kt
@@ -48,5 +48,13 @@ fun ScreenMain() {
                 productId = backStackEntry.arguments!!.getString("productId")!!,
             )
         }
+
+        composable(Routes.IndividualProductUpdatePage.route+"/{productId}",
+            arguments = listOf(navArgument("productId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            IndividualProductUpdatePage(navController = navController,
+                productId = backStackEntry.arguments!!.getString("productId")!!,
+            )
+        }
     }
 }


### PR DESCRIPTION
Resolves #182 

The edit button in the IndividualProduct does not work, clicking it will cause the app to crash.

Solution:
- Fix bug mismatched naming IndividualProductUpdatePage. 
- Create navController in ScreenMain

Expect behavior:

https://github.com/SeattleColleges/belindas-closet-android/assets/72054441/8716bd73-e21b-4d09-87e4-62ade01d8600





