### PR TITLE
belindas_closet_android_3_209_go_back_button_fix

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/screen/AddProduct.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/AddProduct.kt
@@ -35,6 +35,9 @@ import androidx.compose.ui.unit.dp
 import com.example.belindas_closet.Routes
 import com.example.belindas_closet.model.Product
 import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+import com.example.belindas_closet.MainActivity
 import com.example.belindas_closet.model.ProductGender
 import com.example.belindas_closet.model.ProductSizes
 import com.example.belindas_closet.model.ProductSizePantsInseam
@@ -74,11 +77,11 @@ fun AddProductPage(navController: NavHostController) {
     /* Back arrow that navigates back to login page */
 //comment for CI
     TopAppBar(
-        title = { Text("Home") }, /* todo: change destination where arrow navigates to */
+        title = { Text("Back") },
         navigationIcon = {
             IconButton(
                 onClick = {
-                    navController.navigate(Routes.Home.route) /* Navigate back to home page */
+                    navController.popBackStack();
                 }
             ) {
                 Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")

--- a/app/src/main/java/com/example/belindas_closet/screen/AdminView.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/AdminView.kt
@@ -71,7 +71,7 @@ fun AdminView(navController: NavHostController) {
             }
             Button(
                 onClick = {
-                    /*TODO add navigation logic to view list of all products in db*/
+                    navController.navigate(Routes.Home.route)
                 },
                 modifier = Modifier
                     .padding(4.dp)


### PR DESCRIPTION
resolves #211

previously, pressing the go back arrow on the add product page returned the user to the home page no matter what.
Now it should return the user to whatever page they were previously on whether it was the admin page or the home page.

This branch is branched off the branch for PR #214 so that should get approved before this one