### PR TITLE
belindas-closet-android_4_235_edit-option-visiblity

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/SignUpRequest.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/SignUpRequest.kt
@@ -8,6 +8,9 @@ enum class Role(val role: String) {
     @SerialName("admin")
     ADMIN("admin"),
 
+    @SerialName("creator")
+    CREATOR("creator"),
+
     @SerialName("user")
     USER("user")
 }

--- a/app/src/main/java/com/example/belindas_closet/screen/IndividualProduct.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/IndividualProduct.kt
@@ -36,6 +36,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.window.Popup
+import com.example.belindas_closet.MainActivity
+import com.example.belindas_closet.data.network.dto.auth_dto.Role
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -58,12 +60,18 @@ fun IndividualProductPage(navController: NavController, productId: String) {
             }
         },
         actions = {
-            IconButton(
-                onClick = {
-                    navController.navigate(Routes.IndividualProductUpdatePage.route + "/$productId")
+            /*  Edit option visibility */
+            val userRole = MainActivity.getPref().getString("userRole", Role.USER.name)?.let {
+                Role.valueOf(it)
+            } ?: Role.USER
+            if (userRole == Role.ADMIN || userRole == Role.CREATOR) {
+                IconButton(
+                    onClick = {
+                        navController.navigate(Routes.IndividualProductUpdatePage.route + "/$productId")
+                    }
+                ) {
+                    Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
                 }
-            ) {
-                Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
             }
             IconButton(
                 onClick = {

--- a/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
@@ -42,6 +42,7 @@ import com.example.belindas_closet.MainActivity
 import com.example.belindas_closet.R
 import com.example.belindas_closet.Routes
 import com.example.belindas_closet.data.Datasource
+import com.example.belindas_closet.data.network.dto.auth_dto.Role
 import com.example.belindas_closet.model.Product
 import com.example.belindas_closet.model.ProductType
 
@@ -70,15 +71,18 @@ fun ProductDetailPage(navController: NavController) {
                     }
                 },
                 actions = {
-                    IconButton(
-                        onClick = {
-                            //TODO: verify that the user is an admin or the owner of the product
-                            //If yes, then navigate to the update page
-                            navController.navigate(Routes.Update.route)
-                            //Else, navigate to the login page
+                    /*  Edit option visibility */
+                    val userRole = MainActivity.getPref().getString("userRole", Role.USER.name)?.let {
+                        Role.valueOf(it)
+                    } ?: Role.USER
+                    if (userRole == Role.ADMIN || userRole == Role.CREATOR) {
+                        IconButton(
+                            onClick = {
+                                navController.navigate(Routes.Update.route)
+                            }
+                        ) {
+                            Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
                         }
-                    ) {
-                        Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
                     }
                     IconButton(
                         onClick = {
@@ -186,5 +190,4 @@ fun DropDownCategoryList(drawerState: DrawerValue, navController: NavController,
         }
     }
 }
-
 


### PR DESCRIPTION
Resolves #235 

This PR makes it so that the edit option (pencil icon on Product Details page and Individual Products page) is only available to admins and creators and not to users without the appropriate role or users that are signed out. They will not be able to have access to editing options or altering the products listed. 

Related to User Story #163