### PR TITLE
belindas-closet-android_5_271_add-profile-dropdown

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/Routes.kt
+++ b/app/src/main/java/com/example/belindas_closet/Routes.kt
@@ -15,4 +15,5 @@ sealed class Routes (val route: String) {
     object CreatorView: Routes("Creator_View")
     object EditUserRole: Routes("Edit User Role")
     object DonationInfo: Routes("Donation_Info")
+    object Dashboard: Routes("Dashboard")
 }

--- a/app/src/main/java/com/example/belindas_closet/screen/AddProduct.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/AddProduct.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,10 +22,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Button
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,6 +43,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,6 +64,7 @@ import androidx.navigation.NavHostController
 import coil.compose.rememberAsyncImagePainter
 import com.example.belindas_closet.MainActivity
 import com.example.belindas_closet.R
+import com.example.belindas_closet.Routes
 import com.example.belindas_closet.data.network.dto.auth_dto.Role
 import com.example.belindas_closet.data.network.dto.product_dto.ProductRequest
 import com.example.belindas_closet.data.network.product.ProductService
@@ -71,14 +76,12 @@ import com.example.belindas_closet.model.ProductSizeShoes
 import com.example.belindas_closet.model.ProductSizes
 import com.example.belindas_closet.model.ProductType
 import kotlinx.coroutines.launch
-import androidx.compose.runtime.rememberCoroutineScope
-import com.example.belindas_closet.Routes
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddProductPage(navController: NavHostController) {
-
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
     var selectedProductType by remember { mutableStateOf(ProductType.SHOES) }
     var selectedProductGender by remember { mutableStateOf(ProductGender.NON_BINARY) }
     var selectedProductSizeShoe by remember { mutableStateOf(ProductSizeShoes.SELECT_SIZE) }
@@ -108,6 +111,21 @@ fun AddProductPage(navController: NavHostController) {
                     }
                 },
                 actions = {
+                    Row {
+                        IconButton(
+                            onClick = {
+                                profileDropdownState = DrawerValue.Open
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.AccountCircle,
+                                contentDescription = "Profile dropdown"
+                            )
+                        }
+                        ProfileDropdown(profileDropdownState, navController) {
+                            profileDropdownState = DrawerValue.Closed
+                        }
+                    }
                     IconButton(
                         onClick = {
                             // Handle menu icon click

--- a/app/src/main/java/com/example/belindas_closet/screen/AdminView.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/AdminView.kt
@@ -2,8 +2,6 @@ package com.example.belindas_closet.screen
 
 import android.widget.Toast
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,22 +13,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ExitToApp
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Button
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,6 +42,7 @@ import com.example.belindas_closet.Routes
 @Composable
 fun AdminView(navController: NavHostController) {
     val current = LocalContext.current
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
     Row(
         modifier = Modifier
             .height(75.dp)
@@ -54,7 +52,21 @@ fun AdminView(navController: NavHostController) {
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         NSCLogo()
-        Icon(Icons.Filled.ExitToApp, contentDescription="Logout",
+        Row {
+            IconButton(
+                onClick = {
+                    profileDropdownState = DrawerValue.Open
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = "Profile dropdown"
+                )
+            }
+            ProfileDropdown(profileDropdownState, navController) {
+                profileDropdownState = DrawerValue.Closed
+            }
+            Icon(Icons.Filled.ExitToApp, contentDescription="Logout",
             modifier = Modifier.clickable {
                 MainActivity.getPref().edit().remove("token").commit()
                 MainActivity.getPref().edit().remove("userRole").commit()
@@ -64,7 +76,8 @@ fun AdminView(navController: NavHostController) {
                     "Logged Out",
                     Toast.LENGTH_SHORT
                 ).show()
-            })
+            }.padding(top = 10.dp))
+        }
     }
     Row(
         modifier = Modifier

--- a/app/src/main/java/com/example/belindas_closet/screen/CreatorView.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/CreatorView.kt
@@ -2,8 +2,6 @@ package com.example.belindas_closet.screen
 
 import android.widget.Toast
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,22 +13,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ExitToApp
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Button
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,6 +42,7 @@ import com.example.belindas_closet.Routes
 @Composable
 fun CreatorView(navController: NavHostController) {
     val current = LocalContext.current
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
     Row(
         modifier = Modifier
             .height(75.dp)
@@ -54,17 +52,32 @@ fun CreatorView(navController: NavHostController) {
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         NSCLogo()
-        Icon(Icons.Filled.ExitToApp, contentDescription="Logout",
-            modifier = Modifier.clickable {
-                MainActivity.getPref().edit().remove("token").commit()
-                MainActivity.getPref().edit().remove("userRole").commit()
-                navController.navigate(Routes.Home.route)
-                Toast.makeText(
-                    current,
-                    "Logged Out",
-                    Toast.LENGTH_SHORT
-                ).show()
-            })
+        Row {
+            IconButton(
+                onClick = {
+                    profileDropdownState = DrawerValue.Open
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = "Profile dropdown"
+                )
+            }
+            ProfileDropdown(profileDropdownState, navController) {
+                profileDropdownState = DrawerValue.Closed
+            }
+            Icon(Icons.Filled.ExitToApp, contentDescription="Logout",
+                modifier = Modifier.clickable {
+                    MainActivity.getPref().edit().remove("token").commit()
+                    MainActivity.getPref().edit().remove("userRole").commit()
+                    navController.navigate(Routes.Home.route)
+                    Toast.makeText(
+                        current,
+                        "Logged Out",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }.padding(top = 10.dp))
+        }
     }
     Row(
         modifier = Modifier

--- a/app/src/main/java/com/example/belindas_closet/screen/DonationInfo.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/DonationInfo.kt
@@ -3,20 +3,27 @@ package com.example.belindas_closet.screen
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,12 +33,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.example.belindas_closet.MainActivity
 import com.example.belindas_closet.R
 import com.example.belindas_closet.Routes
+import com.example.belindas_closet.data.network.dto.auth_dto.Role
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DonationInfoPage(navController: NavController) {
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
 
     /* Back arrow that navigates back to Home page */
     TopAppBar(
@@ -46,6 +56,26 @@ fun DonationInfoPage(navController: NavController) {
             }
         },
         actions = {
+            val userRole = MainActivity.getPref().getString("userRole", Role.USER.name)?.let {
+                Role.valueOf(it)
+            } ?: Role.USER
+            if (userRole == Role.ADMIN || userRole == Role.CREATOR) {
+                Row {
+                    IconButton(
+                        onClick = {
+                            profileDropdownState = DrawerValue.Open
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.AccountCircle,
+                            contentDescription = "Profile dropdown"
+                        )
+                    }
+                    ProfileDropdown(profileDropdownState, navController) {
+                        profileDropdownState = DrawerValue.Closed
+                    }
+                }
+            }
             IconButton(
                 onClick = {
                 }
@@ -54,6 +84,7 @@ fun DonationInfoPage(navController: NavController) {
             }
         }
     )
+
 
     Column(
         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/belindas_closet/screen/EditUserRole.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/EditUserRole.kt
@@ -11,9 +11,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Card
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -41,6 +43,7 @@ import com.example.belindas_closet.model.User
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditUserRole(navController: NavController) {
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
 
     Scaffold(modifier = Modifier.fillMaxSize(), topBar = {
         /* Back arrow that navigates back to login page */
@@ -51,6 +54,23 @@ fun EditUserRole(navController: NavController) {
                 Icon(
                     imageVector = Icons.Default.ArrowBack, contentDescription = "Back to Home page"
                 )
+            }
+        },
+        actions = {
+            Row {
+                IconButton(
+                    onClick = {
+                        profileDropdownState = DrawerValue.Open
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AccountCircle,
+                        contentDescription = "Profile dropdown"
+                    )
+                }
+                ProfileDropdown(profileDropdownState, navController) {
+                    profileDropdownState = DrawerValue.Closed
+                }
             }
         })
     }) { innerPadding ->

--- a/app/src/main/java/com/example/belindas_closet/screen/Home.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Home.kt
@@ -46,6 +46,7 @@ import com.example.belindas_closet.MainActivity
 import com.example.belindas_closet.R
 import com.example.belindas_closet.Routes
 import com.example.belindas_closet.data.Datasource
+import com.example.belindas_closet.data.network.dto.auth_dto.Role
 import com.example.belindas_closet.model.Product
 import com.example.belindas_closet.model.ProductType
 
@@ -53,7 +54,7 @@ import com.example.belindas_closet.model.ProductType
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomePage(navController: NavController) {
-    var drawerState by remember { mutableStateOf(DrawerValue.Closed) }
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
 
     TopAppBar(
         title = { Text("") },
@@ -78,19 +79,24 @@ fun HomePage(navController: NavController) {
                     modifier = Modifier.padding(10.dp)
                 )
             }
-            Row {
-                IconButton(
-                    onClick = {
-                        drawerState = DrawerValue.Open
+            val userRole = MainActivity.getPref().getString("userRole", Role.USER.name)?.let {
+                Role.valueOf(it)
+            } ?: Role.USER
+            if (userRole == Role.ADMIN || userRole == Role.CREATOR ) {
+                Row {
+                    IconButton(
+                        onClick = {
+                            profileDropdownState = DrawerValue.Open
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.AccountCircle,
+                            contentDescription = "Profile dropdown"
+                        )
                     }
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.AccountCircle,
-                        contentDescription = "Profile dropdown"
-                    )
-                }
-                ProfileDropdown(drawerState, navController) {
-                    drawerState = DrawerValue.Closed
+                    ProfileDropdown(profileDropdownState, navController) {
+                        profileDropdownState = DrawerValue.Closed
+                    }
                 }
             }
             IconButton(
@@ -248,9 +254,9 @@ fun NSCLogo() {
 }
 
 @Composable
-fun ProfileDropdown(drawerState: DrawerValue, navController: NavController, onDismissRequest: () -> Unit = {}) {
+fun ProfileDropdown(profileDropdownState: DrawerValue, navController: NavController, onDismissRequest: () -> Unit = {}) {
     DropdownMenu(
-        drawerState == DrawerValue.Open,
+        profileDropdownState == DrawerValue.Open,
         onDismissRequest = onDismissRequest,
         modifier = Modifier
             .padding(8.dp)

--- a/app/src/main/java/com/example/belindas_closet/screen/Home.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Home.kt
@@ -78,18 +78,20 @@ fun HomePage(navController: NavController) {
                     modifier = Modifier.padding(10.dp)
                 )
             }
-            IconButton(
-                onClick = {
-                    drawerState = DrawerValue.Open
+            Row {
+                IconButton(
+                    onClick = {
+                        drawerState = DrawerValue.Open
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AccountCircle,
+                        contentDescription = "Profile dropdown"
+                    )
                 }
-            ) {
-                Icon(
-                    imageVector = Icons.Default.AccountCircle,
-                    contentDescription = "Profile dropdown"
-                )
-            }
-            ProfileDropdown(drawerState, navController) {
-                drawerState = DrawerValue.Closed
+                ProfileDropdown(drawerState, navController) {
+                    drawerState = DrawerValue.Closed
+                }
             }
             IconButton(
                 onClick = {
@@ -258,8 +260,8 @@ fun ProfileDropdown(drawerState: DrawerValue, navController: NavController, onDi
             Text("Dashboard", color = Color.Black)
         }
         TextButton(onClick = {
-            MainActivity.getPref().edit().remove("token").commit()
-            MainActivity.getPref().edit().remove("userRole").commit()
+            MainActivity.getPref().edit().remove("token").apply()
+            MainActivity.getPref().edit().remove("userRole").apply()
             navController.navigate(Routes.Home.route)
         }) {
             Text("Sign Out", color = Color.Black)

--- a/app/src/main/java/com/example/belindas_closet/screen/Home.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Home.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -67,6 +68,16 @@ fun HomePage(navController: NavController) {
                     painter = painterResource(R.drawable.info_icon),
                     contentDescription = "Donation Info page",
                     modifier = Modifier.padding(10.dp)
+                )
+            }
+            IconButton(
+                onClick = {
+                    // add links
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = "Profile dropdown"
                 )
             }
             IconButton(

--- a/app/src/main/java/com/example/belindas_closet/screen/Home.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Home.kt
@@ -17,6 +17,8 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -24,6 +26,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,10 +49,12 @@ import com.example.belindas_closet.data.Datasource
 import com.example.belindas_closet.model.Product
 import com.example.belindas_closet.model.ProductType
 
-//TODO Add Product Catefories to Navbar
+//TODO Add Product Categories to Navbar
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomePage(navController: NavController) {
+    var drawerState by remember { mutableStateOf(DrawerValue.Closed) }
+
     TopAppBar(
         title = { Text("") },
         actions = {
@@ -72,13 +80,16 @@ fun HomePage(navController: NavController) {
             }
             IconButton(
                 onClick = {
-                    // add links
+                    drawerState = DrawerValue.Open
                 }
             ) {
                 Icon(
                     imageVector = Icons.Default.AccountCircle,
                     contentDescription = "Profile dropdown"
                 )
+            }
+            ProfileDropdown(drawerState, navController) {
+                drawerState = DrawerValue.Closed
             }
             IconButton(
                 onClick = {
@@ -195,7 +206,7 @@ fun TypeCard(productType: ProductType, navController: NavController) {
 
 @Composable
 fun ProductTypeList(products: List<Product>, navController: NavController) {
-    val typeList = ProductType.values().sortedWith(compareBy { it.type });
+    val typeList = ProductType.values().sortedWith(compareBy { it.type })
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Top,
@@ -232,4 +243,26 @@ fun NSCLogo() {
         painter = painterResource(id = R.drawable.nsc_v_logo),
         contentDescription = stringResource(id = R.string.home_nsc_logo_description)
     )
+}
+
+@Composable
+fun ProfileDropdown(drawerState: DrawerValue, navController: NavController, onDismissRequest: () -> Unit = {}) {
+    DropdownMenu(
+        drawerState == DrawerValue.Open,
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier
+            .padding(8.dp)
+    ) {
+        // Dropdown menu items
+        TextButton(onClick = { navController.navigate(Routes.Dashboard.route) }) {
+            Text("Dashboard", color = Color.Black)
+        }
+        TextButton(onClick = {
+            MainActivity.getPref().edit().remove("token").commit()
+            MainActivity.getPref().edit().remove("userRole").commit()
+            navController.navigate(Routes.Home.route)
+        }) {
+            Text("Sign Out", color = Color.Black)
+        }
+    }
 }

--- a/app/src/main/java/com/example/belindas_closet/screen/IndividualProduct.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/IndividualProduct.kt
@@ -3,40 +3,35 @@ package com.example.belindas_closet.screen
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import com.example.belindas_closet.R
-import com.example.belindas_closet.Routes
-import com.example.belindas_closet.data.Datasource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import androidx.navigation.NavController
 import com.example.belindas_closet.MainActivity
+import com.example.belindas_closet.R
+import com.example.belindas_closet.Routes
+import com.example.belindas_closet.data.Datasource
 import com.example.belindas_closet.data.network.dto.auth_dto.Role
 
 //TODO Add Product Categories to Navbar
@@ -44,8 +39,8 @@ import com.example.belindas_closet.data.network.dto.auth_dto.Role
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun IndividualProductPage(navController: NavController, productId: String) {
-
     var drawerState by remember { mutableStateOf(DrawerValue.Closed) }
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
 
     TopAppBar(
         title = { Text("Back") },
@@ -77,6 +72,21 @@ fun IndividualProductPage(navController: NavController, productId: String) {
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit"
                         )
+                    }
+                    Row {
+                        IconButton(
+                            onClick = {
+                                profileDropdownState = DrawerValue.Open
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.AccountCircle,
+                                contentDescription = "Profile dropdown"
+                            )
+                        }
+                        ProfileDropdown(profileDropdownState, navController) {
+                            profileDropdownState = DrawerValue.Closed
+                        }
                     }
                 }
                     IconButton(

--- a/app/src/main/java/com/example/belindas_closet/screen/IndividualProductUpdate.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/IndividualProductUpdate.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
@@ -54,11 +55,11 @@ import com.example.belindas_closet.MainActivity
 import com.example.belindas_closet.R
 import com.example.belindas_closet.Routes
 import com.example.belindas_closet.data.Datasource
-import com.example.belindas_closet.data.network.product.ArchiveService
-import com.example.belindas_closet.data.network.product.DeleteService
+import com.example.belindas_closet.data.network.dto.auth_dto.Role
 import com.example.belindas_closet.data.network.dto.product_dto.ArchiveRequest
 import com.example.belindas_closet.data.network.dto.product_dto.DeleteRequest
-import com.example.belindas_closet.data.network.dto.auth_dto.Role
+import com.example.belindas_closet.data.network.product.ArchiveService
+import com.example.belindas_closet.data.network.product.DeleteService
 import com.example.belindas_closet.model.Product
 import com.example.belindas_closet.model.ProductSizes
 import kotlinx.coroutines.launch
@@ -69,7 +70,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun IndividualProductUpdatePage(navController: NavController, productId: String) {
     var drawerState by remember { mutableStateOf(DrawerValue.Closed) }
-
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
 
     Scaffold(
         modifier = Modifier
@@ -106,6 +107,21 @@ fun IndividualProductUpdatePage(navController: NavController, productId: String)
                                 imageVector = Icons.Default.Edit,
                                 contentDescription = "Edit"
                             )
+                        }
+                        Row {
+                            IconButton(
+                                onClick = {
+                                    profileDropdownState = DrawerValue.Open
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.AccountCircle,
+                                    contentDescription = "Profile dropdown"
+                                )
+                            }
+                            ProfileDropdown(profileDropdownState, navController) {
+                                profileDropdownState = DrawerValue.Closed
+                            }
                         }
                     }
                     IconButton(

--- a/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/ProductDetail.kt
@@ -5,6 +5,7 @@ import android.content.res.Resources
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Menu
@@ -50,6 +52,7 @@ import com.example.belindas_closet.model.ProductType
 @Composable
 fun ProductDetailPage(navController: NavController) {
     var drawerState by remember { mutableStateOf(DrawerValue.Closed) }
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
 
     Scaffold(
         modifier = Modifier
@@ -82,6 +85,21 @@ fun ProductDetailPage(navController: NavController) {
                             }
                         ) {
                             Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+                        }
+                        Row {
+                            IconButton(
+                                onClick = {
+                                    profileDropdownState = DrawerValue.Open
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.AccountCircle,
+                                    contentDescription = "Profile dropdown"
+                                )
+                            }
+                            ProfileDropdown(profileDropdownState, navController) {
+                                profileDropdownState = DrawerValue.Closed
+                            }
                         }
                     }
                     IconButton(

--- a/app/src/main/java/com/example/belindas_closet/screen/Update.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/Update.kt
@@ -14,11 +14,12 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.DrawerValue
@@ -60,6 +61,7 @@ import kotlinx.coroutines.launch
 fun UpdatePage(navController: NavController) {
     var hiddenProducts by remember { mutableStateOf(setOf<String>()) }
     var drawerState by remember { mutableStateOf(DrawerValue.Closed) }
+    var profileDropdownState by remember { mutableStateOf(DrawerValue.Closed) }
 
     Scaffold(
         modifier = Modifier
@@ -91,6 +93,21 @@ fun UpdatePage(navController: NavController) {
                                 imageVector = Icons.Default.Edit,
                                 contentDescription = "Edit"
                             )
+                        }
+                        Row {
+                            IconButton(
+                                onClick = {
+                                    profileDropdownState = DrawerValue.Open
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.AccountCircle,
+                                    contentDescription = "Profile dropdown"
+                                )
+                            }
+                            ProfileDropdown(profileDropdownState, navController) {
+                                profileDropdownState = DrawerValue.Closed
+                            }
                         }
                     }
                     IconButton(


### PR DESCRIPTION
Resolves #271 

This PR adds a profile dropdown to every page (except the Sign Up, Login, Forgot Password, and ResetPassword pages). On pages other than the AdminView, CreatorView, Add Product, and Edit User Role pages, I added role-based access to the profile dropdown so that only users signed in as admin and creators would be able to see the profile dropdown. Pressing the profile dropdown opens a dropdown menu with a dashboard link and sign out link. The dashboard link is currently not functioning. Below are some screenshots of some of the pages.

Home page (not logged in as admin or creator):
<img width="299" alt="home page not logged in" src="https://github.com/SeattleColleges/belindas-closet-android/assets/77591083/8f69fae1-afe4-4d2a-b0e8-742c4fd331a6">

Home page (logged in as admin or creator):
<img width="295" alt="home page logged in as admin" src="https://github.com/SeattleColleges/belindas-closet-android/assets/77591083/0e414a82-a535-4536-a9f9-4b79af926e01">

Admin page:
<img width="296" alt="adminview page" src="https://github.com/SeattleColleges/belindas-closet-android/assets/77591083/1693f811-a857-4bfe-83c8-1b6a58686f3e">

Product Detail page:
<img width="310" alt="productdetail page" src="https://github.com/SeattleColleges/belindas-closet-android/assets/77591083/de44c8ea-77b4-46c1-b045-baa06cd317ac">



Related to #270 