### PR TITLE
belindas-closet-android_5_284_update-ui-edit-user-role-page

### DIFF
--- a/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/SignUpRequest.kt
+++ b/app/src/main/java/com/example/belindas_closet/data/network/dto/auth_dto/SignUpRequest.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class Role(val role: String) {
+enum class Role(var role: String) {
     @SerialName("admin")
     ADMIN("admin"),
 

--- a/app/src/main/java/com/example/belindas_closet/model/User.kt
+++ b/app/src/main/java/com/example/belindas_closet/model/User.kt
@@ -6,6 +6,6 @@ data class User(
     val userFirstName: String,
     val userLastName: String,
     val userEmail: String,
-    val userRole: Role,
+    var userRole: Role,
     val userId: String = "0"
 )

--- a/app/src/main/java/com/example/belindas_closet/screen/EditUserRole.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/EditUserRole.kt
@@ -123,7 +123,7 @@ fun UserCard(user: User, navController: NavController) {
                         isEditingRole = false
                         user.userRole.role = selectedRole
                         isSave = true
-                    }, onDismiss = { isEditingRole = false})
+                    }, onDismiss = { isEditingRole = false })
                 }
                 if (isSave) {
                     Toast.makeText(
@@ -131,6 +131,7 @@ fun UserCard(user: User, navController: NavController) {
                         "User's role has been updated!",
                         Toast.LENGTH_SHORT
                     ).show()
+                    isSave = false
                 }
             }
         }

--- a/app/src/main/java/com/example/belindas_closet/screen/EditUserRole.kt
+++ b/app/src/main/java/com/example/belindas_closet/screen/EditUserRole.kt
@@ -1,5 +1,6 @@
 package com.example.belindas_closet.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -31,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -92,6 +94,7 @@ fun UserCard(user: User, navController: NavController) {
     var selectedRole by remember { mutableStateOf(user.userRole.role) }
     var isCancel by remember { mutableStateOf(false) }
     var isSave by remember { mutableStateOf(false) }
+    val current = LocalContext.current
 
     Card(
         modifier = Modifier
@@ -105,8 +108,7 @@ fun UserCard(user: User, navController: NavController) {
         ) {
             CustomTextField(text = user.userFirstName + " " + user.userLastName)
             CustomTextField(text = user.userEmail)
-            CustomTextField(
-                text = user.userRole.role.lowercase().replaceFirstChar { it.uppercase() })
+            CustomTextField(text = user.userRole.role.lowercase().replaceFirstChar { it.uppercase() })
             Row(
                 modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically
             ) {
@@ -119,7 +121,16 @@ fun UserCard(user: User, navController: NavController) {
                     RoleSelectionDialog(selectedRole = selectedRole, onRoleSelected = {
                         selectedRole = it
                         isEditingRole = false
-                    }, onDismiss = { isEditingRole = false })
+                        user.userRole.role = selectedRole
+                        isSave = true
+                    }, onDismiss = { isEditingRole = false})
+                }
+                if (isSave) {
+                    Toast.makeText(
+                        current,
+                        "User's role has been updated!",
+                        Toast.LENGTH_SHORT
+                    ).show()
                 }
             }
         }


### PR DESCRIPTION
Resolves #284 

This PR updates the role of the user on the UI when the role is changed and a toast message appears when the role is changed. 

Note: Because this is just updating the UI, the user roles of the sample users in DataSource are not actually being updated.

https://github.com/SeattleColleges/belindas-closet-android/assets/77591083/b18dd98b-fea1-4eca-95dc-0177a1ef6b4e

Relates to #283 